### PR TITLE
Remove fair/kakaotalk from list of bridges

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -32,7 +32,6 @@ What is a Matrix bridge? [Learn more](https://www.beeper.com/faq#what-is-a-bridg
 | IRC                  | [hifi/heisenbridge](https://github.com/hifi/heisenbridge)                                           |
 | GroupMe              | [beeper/groupme](https://github.com/beeper/groupme)                                                 |
 | iMessage             | [beeper/imessage](https://github.com/beeper/imessage)                                               |
-| KakaoTalk <sup><sub>[Sponsored]</sub></sup> | [fair/kakaotalk](https://src.miscworks.net/fair/matrix-appservice-kakaotalk.git)      |
 | LINE <sup><sub>[Sponsored]</sub></sup>      | [fair/line](https://src.miscworks.net/fair/matrix-puppeteer-line.git)                 |
 
 <sup><sub>[Sponsored]</sub></sup> indicates community-maintained bridges sponsored by Beeper.


### PR DESCRIPTION
It's broken and unmaintained.

In short, `node-kakao`, the underlying SDK, is severely outdated and does not even complete a login flow anymore, as there's a bunch of missing headers and payload fields, and the RSA key is out of date.

The bridge itself is also broken in that it uses a now deprecated e2ee syncing protocol, which doesn't work with Beeper's current hungryserv server. 

I wrote up more of my findings [here](https://jusung.dev/posts/kakao-talk-is-making-me-local/#setting-up-an-existing-bridge).

I am in the process of writing my own bridge, and my own underlying sdk, because there seems to be no working alternative. In the mean time, we shouldn't lead users to believe that this one still functions.